### PR TITLE
cogsci.sty: close anonymization conditional with \fi

### DIFF
--- a/cogsci.sty
+++ b/cogsci.sty
@@ -125,8 +125,8 @@
 	\else \iftwopagesummary
              \bf\@author
         \else
-        {\bf \large Anonymous CogSci submission} % Avoiding common accidental de-anonymization issue. --MM 
-
+             {\bf \large Anonymous CogSci submission} % Avoiding common accidental de-anonymization issue. --MM
+        \fi
 	\fi
     \end{tabular}}
 


### PR DESCRIPTION
I was having trouble on [Overleaf](https://overleaf.com) switching from anonymized to non-anonymized output using this template. It looks like a conditional in one of the anyonymization clauses wasn't closed, and this change fixed my problem.